### PR TITLE
[Feature] Add customizable template for the Proxmox VM template description

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 downloads/
 packer/proxmox-host.auto.pkrvars.hcl
 scripts/packer/uploads/personalize.sh
+scripts/packer/templates/vm-description.md

--- a/README.md
+++ b/README.md
@@ -73,7 +73,9 @@ This omits using `Make` or `Task` to run Packer.
 
 5. Update `packer/proxmox-template.auto.pkrvars.hcl` with any desired options for the VM template settings.
 
-6. Build the template:
+6. Rename `scripts/packer/templates/example-vm-description.md` to `scripts/packer/templates/vm-description.md` and update it to your specifications.
+
+7. Build the template:
 
    ```bash
    packer build ./packer

--- a/packer/build.pkr.hcl
+++ b/packer/build.pkr.hcl
@@ -26,6 +26,12 @@ build {
     destination = "/tmp/personalize.sh"
   }
 
+  # Uploads ./scripts/packer/templates/vm-description.md to /tmp on the Proxmox host
+  provisioner "file" {
+  source      = "./scripts/packer/templates/vm-description.md"
+  destination = "/tmp/vm-description.md"
+  }
+
   # Uploads and executes the create-template.sh shell script on the Proxmox host
   provisioner "shell" {
     environment_vars = [

--- a/packer/proxmox-template.auto.pkrvars.hcl
+++ b/packer/proxmox-template.auto.pkrvars.hcl
@@ -27,5 +27,4 @@ proxmox_disk_image_volume = "local-zfs"
 
 
 # VM Template Network Bridge Settings (Default: vmbr0)
-template_vm_network_bridge = "vmbr0" #
-# template_vm_network_bridge = "vmbr1"
+template_vm_network_bridge = "vmbr0"

--- a/scripts/packer/create-template.sh
+++ b/scripts/packer/create-template.sh
@@ -30,13 +30,17 @@ rm /tmp/personalize.sh || echo "personalize.sh script not present"
 # Remove existing template
 qm destroy "$VM_ID" --destroy-unreferenced-disks --purge || echo "VM not present"
 
-# Generate BUILD_DATETIME
+# Generate and export BUILD_DATETIME
 BUILD_DATETIME=$(date +"%Y-%m-%d at %H:%M")
+export BUILD_DATETIME
+
+# Read and substitute variables in the Markdown description
+VM_DESCRIPTION=$(envsubst < /tmp/vm-description.md)
 
 # Create a new VM
 qm create "$VM_ID" \
   --name "$VM_NAME" \
-  --description "$VM_NAME template built on $BUILD_DATETIME by Packer" \
+  --description "$VM_DESCRIPTION" \
   --ostype l26 \
   --machine q35 \
   --bios ovmf \
@@ -57,3 +61,6 @@ qm template "$VM_ID"
 
 # Cleanup *.img files
 rm /tmp/*.img
+
+# Clean up uploaded Markdown file
+rm /tmp/vm-description.md

--- a/scripts/packer/templates/example-vm-description.md
+++ b/scripts/packer/templates/example-vm-description.md
@@ -1,0 +1,16 @@
+<!-- ❗❗❗
+This file is used to provide the content for the vm's description in Proxmox.
+Rename it to `vm-description.md` and update the content accordingly.
+You can pass environment variables through to this, as long as they are exported.
+❗❗❗ -->
+
+# ${VM_NAME} Template
+
+**Built**: ${BUILD_DATETIME}
+
+## Customizations
+
+- **Apt-Cacher Proxy**: <http://192.168.40.12:3142>
+- **Update Command**: Runs `apt update && apt upgrade -y`
+- **Time Sync**: Chrony with NTP server 192.168.20.20
+- **Guest Agent**: QEMU Guest Agent enabled

--- a/scripts/packer/templates/example-vm-description.md
+++ b/scripts/packer/templates/example-vm-description.md
@@ -10,7 +10,7 @@ You can pass environment variables through to this, as long as they are exported
 
 ## Customizations
 
-- **Apt-Cacher Proxy**: <http://192.168.40.12:3142>
+- **Apt-Cacher Proxy**: <http://192.168.1.2:3142>
 - **Update Command**: Runs `apt update && apt upgrade -y`
-- **Time Sync**: Chrony with NTP server 192.168.20.20
+- **Time Sync**: Chrony with NTP server 192.168.1.4
 - **Guest Agent**: QEMU Guest Agent enabled


### PR DESCRIPTION
This PR enables the use of a markdown template for the VM template's description.
It provides a starting point for including information, such as customizations.
Proxmox will render the information when the template is viewed.
The description is copied when the template is cloned.